### PR TITLE
read static files with filed instead of createReadStream

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ http.createServer(function(req, resp) {
       }
     })
   } else if(fs.existsSync(filepath)) {
-    stream = fs.createReadStream(filepath)
+    stream = filed(filepath)
   } else if(/html/.test(req.headers.accept || '')) {
     logged_pathname = logged_pathname.blue + ' ' + '(generated)'.grey
     stream = response_stream(fake_index(query))


### PR DESCRIPTION
This tiny change reads static files with `filed` instead of with `fs.createReadStream` so that they are sent with the correct mime-type (currently, an annoying mime-type warning shows up in chrome saying js files were interpreted as js but transferred as text/plain). 

There is a minor trade-off here: because of a [bug](https://github.com/mikeal/filed/issues/27) in `filed`, the stream created by the `filed()` method never actually emits an 'end' event, which means that the `log()` function in beefy doesn't get triggered. IMHO this is better than that annoying mime-type warning. Also, mikeal is bound to fix this sooner or later (hopefully sooner).
