### PR TITLE
Spawn browserify on Windows

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -139,6 +139,7 @@ function which_browserify(parsed) {
   }
 
   var local = path.join(process.cwd(), 'node_modules/.bin/browserify')
+  if (process.platform === 'win32') local += '.cmd'
   if(fs.existsSync(local)) {
     return local
   }


### PR DESCRIPTION
Hey! This change will allow `node_modules/.bin/browserify.cmd` to be spawned on Windows. For some reason some windows environments will only spawn a binary if `.cmd` is affixed. Tested with voxel-hello-world and appears to be the only thing needed to support windows. Thanks!
