### PR TITLE
Windows fix for global browserify

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -144,7 +144,7 @@ function which_browserify(parsed) {
   if(fs.existsSync(local)) {
     return local
   }
-  return 'browserify'
+  return 'browserify' + ((process.platform === 'win32') ? '.cmd' : '')
 }
 
 function info(what) {


### PR DESCRIPTION
Fixes GH-14.

Looks like the global `browserify` binary also needs `.cmd` appended in order to be spawned.
