### PR TITLE
allow custom request handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,26 @@ beefy exports one function which returns a http server created from `http.create
 * `browserify_args` (array of strings) arguments to the browserify command. use e.g. `[ '-d' ]` for debug mode.
 * `entry_points` (object) dictionary for your entry points and corresponding file to browserify. see example below.
 * `live_reload` (boolean) enable live reload if set
-* `log` (function) logging callback. see signature below.
+* `log` (function) optional logging callback. see signature below.
+* `custom_handler` (function) optional custom request handler. return true in handler to prevent beefy from returning 404, see below.
 
 ```js
 var beefy = require('beefy')
 var entry_points = { 'bundle.js': 'path/to/some/js/file.js' }
-var server = beefy('path/to/wwwroot', 'browserify', [ '-d' ], entry_points, true, log)
+var server = beefy('path/to/wwwroot', 'browserify', [ '-d' ], entry_points, true, log,
+                   custom_handler)
 server.listen(9966)
+
 function log(code, time, bytesize, logged_pathname, color) {}
+
+function custom_handler(req, resp) {
+  if (req.url == '/foo') {
+    // custom handling of '/foo'
+    resp.end('bar\n')
+    return true
+  }
+  // delegate back to beefy
+}
 
 ```
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,10 +16,11 @@ var response_stream = require('response-stream')
 
 var fake_index_html = fs.readFileSync(path.join(__dirname, 'fake_index.html'), 'utf8')
 
-function beefy(cwd, browserify_path, browserify_args, entry_points, live_reload, log) {
+function beefy(cwd, browserify_path, browserify_args, entry_points, live_reload, log, custom_handler) {
   var server = http.createServer(beefy_server)
 
   log = log || function noop() {}
+  custom_handler = custom_handler || function noop() {}
 
   if(!live_reload) {
     return server
@@ -84,6 +85,8 @@ function beefy(cwd, browserify_path, browserify_args, entry_points, live_reload,
       resp.end(';('+live_reload_code+')()')
       return
     }
+
+    if(!stream && custom_handler(req, resp)) return
 
     if(!stream && /html/.test(req.headers.accept || '')) {
       logged_pathname = logged_pathname.blue + ' ' + '(generated)'


### PR DESCRIPTION
Is this something you want? I think it's nice to be able to serve any static content with beefy and have live reload and at the same time add extra functionality on top with a custom request handler. If you want it and are not happy with the implementation details, I'll be happy to adjust to your satisfaction.

Cheers
