### PR TITLE
Enable opening of custom file

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -99,7 +99,7 @@ function run() {
       }
       port = _port
       done()
-      var filePath = parsed.open === 'true' ? '' : parsed.open
+      var filePath = parsed.open === 'true' || parsed.open.charAt(0) === '-' ? '' : parsed.open
       open('http://localhost:'+_port+'/'+filePath)
     })    
   }


### PR DESCRIPTION
The `--open` option is super convenient, but my file isn't always named `index.html`. This small change lets you do something like `beefy test.js:bundle.js --open test.html` and `http://localhost:8000/test.html` will be opened in the browser.
