### PR TITLE
Add support for opening a custom url via --url option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -95,9 +95,7 @@ function run() {
 
   if(parsed.url) {
     open(parsed.url)
-  }
-
-  if(parsed.open) {
+  } else if(parsed.open) {
     return portfinder.getPort(function(err, _port) {
       if(err) {
         console.log('could not automatically find port.')


### PR DESCRIPTION
I use a few hosts aliases when developing locally to facilitate some url-driven aspects of our app, so being able to open http://localfoo:9966/some/weird/path.html would be SUPER handy.

Really small change, obviously. Specifying the option type as `url` means `nopt` will actually verify that it's a valid URL and will not parse it if it's not. Whaddya say, 2 PRs merged in one day? :)
