### PR TITLE
switched to chakidar for file watching

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -6,13 +6,14 @@ var spawn = require('child_process').spawn
   , url = require('url')
   , fs = require('fs')
 
-var response_stream = require('response-stream')
-  , sse = require('sse-stream')('/-/live-reload')
+var sse = require('sse-stream')('/-/live-reload')
+  , response_stream = require('response-stream')
+  , script_injector = require('script-injector')
+  , ignorepatterns = require('ignorepatterns')
+  , watch = require('chokidar').watch
   , through = require('through')
   , colors = require('colors')
-  , watchr = require('watchr')
   , mime = require('mime')
-  , script_injector = require('script-injector')
 
 var fake_index_html = fs.readFileSync(path.join(__dirname, 'fake_index.html'), 'utf8')
 
@@ -27,6 +28,7 @@ function beefy(cwd, browserify_path, browserify_args, entry_points, live_reload,
   }
 
   var should_reload = false
+    , watch_options = {}
     , connections = []
 
   sse.install(server)
@@ -37,16 +39,18 @@ function beefy(cwd, browserify_path, browserify_args, entry_points, live_reload,
     })
   })
 
-  watchr.watch({
-      path: cwd
-    , listener: do_reload
-    , ignoreHiddenFiles: true
-    , ignorePatterns: true
-  })
+  watch_options.ignored = ignore
+  watch_options.ignoreInitial = true
+
+  watch(cwd, watch_options).on('all', do_reload)
 
   server.reload = do_reload
 
   return server
+
+  function ignore(file) {
+    return /[\/\\]\./.test(file) || ignorepatterns.test(path.basename(file))
+  }
 
   function beefy_server(req, resp) {
     var parsed = url.parse(req.url, true)

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "colors": "~0.6.0-1",
     "through": "~2.2.0",
     "nopt": "~2.1.1",
-    "watchr": "~2.4.3",
     "mime": "~1.2.9",
     "sse-stream": "0.0.4",
     "open": "0.0.3",
     "portfinder": "~0.2.1",
-    "script-injector": "~0.1.0"
+    "script-injector": "~0.1.0",
+    "chokidar": "0.8.1",
+    "ignorepatterns": "1.0.1"
   },
   "bin": {
     "beefy": "./bin/beefy"


### PR DESCRIPTION
fs.watch (and the many modules that depend on it including watchr) have some serious issues and inconsistent cross platform behaviors more [details at the top of the chakidar readme ](https://www.npmjs.org/package/chokidar)  chakidor provides a more responsive and consistent cross platform experience.
