### PR TITLE
Prevent double slashes in URLs when using the API

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function beefy(opts, ready) {
     function toObject(obj, entry) {
       entry = path.resolve(opts.cwd, entry)
 
-      obj[entry.replace(opts.cwd, '/').replace('\\', '/')] = entry
+      obj[entry.replace(opts.cwd, '/').replace('\\', '/').replace(/\/+/g, '/')] = entry
 
       return obj
     }


### PR DESCRIPTION
Otherwise, the following:

``` javascript
beefy({ cwd: root, entries: ['index.js'] })
```

Appears to be resulting in this tag on the default index page:

``` html
<script src="//index.js" type="text/javascript"></script>
```

Thanks! Looks great so far :)
