### PR TITLE
Implement --debug=false.

### DIFF
--- a/lib/args-to-options.js
+++ b/lib/args-to-options.js
@@ -44,7 +44,7 @@ function parse(argv, cwd, ready) {
   parsed.watchify = parsed.watchify === undefined ? true : parsed.watchify
   parsed.index = parsed.i || parsed.index
 
-  if(!parsed.bundler && (parsed.debug === undefined || parsed.debug)) {
+  if(!parsed.bundler && parsed.debug !== 'false') {
     if(bundlerFlags.indexOf('-d') === -1) {
       bundlerFlags.unshift('-d')
     }

--- a/test/tests/args-to-options.js
+++ b/test/tests/args-to-options.js
@@ -86,6 +86,8 @@ function testArgsToOptions(test) {
       , [['--', '-d'], 'handler.bundler.flags.0', '-d']
       , [['--debug'], 'handler.bundler.flags.0', '-d']
       , [[], 'handler.bundler.flags.0', '-d']
+      , [['--debug=false'], 'handler.bundler.flags.0', undefined]
+      , [['--debug', 'false'], 'handler.bundler.flags.0', undefined]
     ]
 
     var pending = args_to_result.length


### PR DESCRIPTION
The argument `--debug=false` is documented but not actually implemented.
This adds the expected functionality and corresponding tests.
