### PR TITLE
Fix for bad cwd default and fix for entries option not getting passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function beefy(opts, ready) {
     Array.isArray(opts) ? {entries: opts} :
     opts
 
-  opts.cwd = opts.cwd || path.dirname(module.parent)
+  opts.cwd = opts.cwd || path.dirname(module.parent.filename)
   opts.entries = opts.entries || []
   opts.bundlerFlags = opts.bundlerFlags || []
   opts.bundler = opts.bundler || null
@@ -23,7 +23,7 @@ function beefy(opts, ready) {
   opts.live = !!opts.live
   opts.watchify = opts.watchify === undefined ? true : opts.watchify
 
-  var args = ['9999']
+  var args = Array.isArray(opts.entries) ? opts.entries.slice() : []
     , innerHandler
 
   if(opts.cwd) {


### PR DESCRIPTION
Beefy is pretty amazing, and I've been using the CLI for a little while now, but today I decided to check out using the API interface, and sort of fell down a rabbit hole discovering bugs. This pull request fixes two of them and leaves the third for someone else. :)

The first bug is that the default for the `cwd` option was getting set to `.`, which was causing the `fixupEntries` function to replace the `.` in say `index.js` with a `/`.

The second bug was that the `entries` option was not actually getting passed to the `setupBundler` function. That would result in the entry points getting served as static files instead of getting bundled.

The third bug that this PR does not fix is that the docs indicate that you can pass an object for the `entries` option. I attempted to add support for this, however doing so causes the "concurrent conns do not trigger a warning" integration test to hang. I spent a long while trying to figure out why to no avail.

Thanks for writing beefy! Please let me know if there are any changes you'd like me to make. (Or feel free to reject…this is my first GitHub PR so I've likely messed something up!)
