### PR TITLE
added `--cache` option for running in “production”

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Provide your own default index! This works great for single page apps,
 as every URL on your site will be redirected to the same HTML file. Every
 instance of `{{entry}}` will be replaced with the entry point of your app.
 
+#### `--cache`
+
+Beefy will cache the bundle. This is useful for running in "production", when you don't expect the bundle to change between requests.
+
 ## api
 
 ```javascript

--- a/lib/args-to-options.js
+++ b/lib/args-to-options.js
@@ -101,6 +101,7 @@ function parse(argv, cwd, ready) {
       , log: hasColor
       , cwd: parsed.cwd
       , realCwd: cwd
+      , cache: parsed.cache
     }
 
     handlerOptions.bundler = {

--- a/lib/handlers/bundle.js
+++ b/lib/handlers/bundle.js
@@ -2,6 +2,9 @@ module.exports = handleEntryPoints
 
 var accumError = require('../accumulate-error.js')
   , ansicolors = require('ansicolors')
+  , es = require('event-stream')
+
+var cache = {}
 
 // opts = {
 //     entries: {
@@ -33,6 +36,11 @@ function handleEntryPoints(opts, io, nextHandler) {
       return nextHandler(server, req, resp, parsed)
     }
 
+    if (opts.cache && cache[parsed.pathname]) {
+      resp.setHeader('content-type', 'text/javascript')
+      return es.readArray(cache[parsed.pathname]).pipe(resp)
+    }
+
     var entryPath = entries[parsed.pathname]
       , args = bundlerOpts.flags.slice()
       , bundler
@@ -49,6 +57,12 @@ function handleEntryPoints(opts, io, nextHandler) {
     bundler.stderr.pipe(accumError(io.error, resp))
     resp.setHeader('content-type', 'text/javascript')
     bundler.stdout.pipe(resp)
+
+    if (opts.cache) {
+      bundler.stdout.pipe(es.writeArray(function(err, data) {
+        cache[parsed.pathname] = data
+      }))
+    }
   }
 
   function toLocal(file) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ansicolors": "~0.3.2",
     "chokidar": "^0.8.4",
     "concat-stream": "^1.4.3",
+    "event-stream": "^3.1.7",
     "find-global-packages": "0.0.1",
     "ignorepatterns": "^1.0.1",
     "leftpad": "0.0.0",


### PR DESCRIPTION
I've had a number of projects where I start using Beefy and when it's ready to ship, I have to figure out a different way of serving it (or deal with the re-bundle delay on each request).

I created this so that I can just change my `npm start` script to be `beefy index.js --debug=false --cache` and throw it up on a server. The first request has the delay for building the bundle, but the subsequent requests serve from the cache.
