### PR TITLE
Throw CLI errors

### DIFF
--- a/bin/beefy
+++ b/bin/beefy
@@ -10,6 +10,6 @@ require('../lib/cli.js')(
 function onready(err) {
   // noop
   if(err) {
-    process.exit(1)
+    throw err
   }
 }


### PR DESCRIPTION
Otherwise, the process will fail silently – throwing the error will display the message and stack trace, making it debugging much simpler.

Thanks!
