### PR TITLE
Add browserify as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "ansicolors": "~0.3.2",
+    "browserify": "^5.10.1",
     "chokidar": "^0.8.4",
     "concat-stream": "^1.4.3",
     "find-global-packages": "0.0.1",


### PR DESCRIPTION
Previously, in beefy 2.x, no error message was emitted when browserify
was not installed globally. Beefy just failed silently.

This solves https://github.com/chrisdickinson/beefy/issues/16 and https://github.com/chrisdickinson/beefy/issues/27.