### PR TITLE
Update chokidar to 0.12.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beefy",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "local development server that aims to make using browserify fast and fun",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "dependencies": {
     "ansicolors": "~0.3.2",
-    "chokidar": "^0.8.4",
+    "chokidar": "^0.12.5",
     "concat-stream": "^1.4.3",
     "find-global-packages": "0.0.1",
     "ignorepatterns": "^1.0.1",


### PR DESCRIPTION
Resolves problems with beefy and live reloading / fs watching on latest OSX. Lots of these kinds of errors:

npm: 2.1.17
node: 0.10.35

```
2015-01-03 12:33 node[11267] (CarbonCore.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-21)
2015-01-03 12:33 node[11267] (CarbonCore.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-21)
2015-01-03 12:33 node[11267] (CarbonCore.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-21)
2015-01-03 12:33 node[11267] (CarbonCore.framework) FSEventStreamStart: register_with_server: ERROR: f2d_register_rpc() => (null) (-21)
```

Updates chokidar to 0.12.5

Other projects having same issues:

https://github.com/substack/watchify/issues/106
https://github.com/joyent/node/issues/5463
https://github.com/ember-cli/ember-cli/issues/2226

etc ;)

Thanks!