### PR TITLE
Specify a path to watch when using live reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function beefy(opts, ready) {
   opts.quiet = opts.quiet === undefined ? true : opts.quiet
   opts.live = !!opts.live
   opts.watchify = opts.watchify === undefined ? true : opts.watchify
+  opts.watchdir = opts.watchdir || opts.cwd
 
   var args = ['9999']
     , innerHandler
@@ -44,6 +45,10 @@ function beefy(opts, ready) {
 
   if('watchify' in opts && !opts.watchify) {
     args.push('--no-watchify')
+  }
+
+  if(opts.watchdir) {
+    args.push('--watchdir', opts.watchdir)
   }
 
   args.push('--')

--- a/lib/args-to-options.js
+++ b/lib/args-to-options.js
@@ -42,6 +42,7 @@ function parse(argv, cwd, ready) {
   parsed.debug = parsed.d || parsed.debug
   parsed.bundler = parsed.browserify || parsed.bundler
   parsed.watchify = parsed.watchify === undefined ? true : parsed.watchify
+  parsed.watchdir = parsed.watchdir || parsed.cwd
   parsed.index = parsed.i || parsed.index
 
   if(!parsed.bundler && parsed.debug !== 'false') {
@@ -101,6 +102,7 @@ function parse(argv, cwd, ready) {
       , log: hasColor
       , cwd: parsed.cwd
       , realCwd: cwd
+      , watchdir: parsed.watchdir
     }
 
     handlerOptions.bundler = {

--- a/lib/handlers/live-reload.js
+++ b/lib/handlers/live-reload.js
@@ -21,7 +21,7 @@ function handleLiveReload(opts, io, nextHandler) {
   var lastUpdate = Date.now()
     , pending = []
 
-  watch(opts.cwd, {
+  watch(opts.watchdir, {
       ignored: ignore
     , useFsEvents: true
     , usePolling: false

--- a/lib/help.js
+++ b/lib/help.js
@@ -42,6 +42,10 @@ beefy path/to/entry.js[:as.js] [PORT] -- [arguments to forward to bundler]
 
     --index file                Use a different autogeneration template
                                 for index.html.
+
+    --watchdir dir              With live reloading, reloads the page when this
+                                directory changes. If not provided, defaults to
+                                cwd.
 */
 
   var str = help + ''


### PR DESCRIPTION
**This is a WIP. Starting the PR now to get feedback.**

I'm proposing a feature which makes it possible to specify a path for the live-reload watcher to watch. This continues to default to cwd, so the change is backward compatible.

The reason I would like this feature is that I'm working on a project that uses coffeescript. Without a `watchdir` option, the page is reloaded as soon as I change a coffeescript file. When the build completes (for me, ~700ms later), the new javascript is now ready, but the live-reload doesn't pick it up. I'm guessing this is because of the throttling on the reload rate here: https://github.com/chrisdickinson/beefy/blob/9bef33b33/lib/handlers/live-reload.js#L32

I saw three options when starting this:
- Reduce the throttling. This means I'll get two reloads: one when the coffeescript changes and one again when the build completes. Not really ideal, but could be workable.
- Add an `ignoredir` option which is somehow passed to chokidar. Currently, chokidar is passed the [ignorepatterns](https://www.npmjs.com/package/ignorepatterns) regex, so adding an option that can be merged with that seemed a little tricky.
- Add this `watchdir` option. 

I've tried this out on my project, passing `watchdir: 'build'` to beefy through the JS API.

Note that I haven't adding any tests or documentation around this. I'll do that if there's interest. If one of those other options (or something else entirely) would be better, I'd be happy to work on that too.