### PR TITLE
Fix Live Reload Reliability

### DIFF
--- a/lib/args-to-options.js
+++ b/lib/args-to-options.js
@@ -2,6 +2,7 @@ module.exports = parse
 
 var minimist = require('minimist')
   , path = require('path')
+  , EventEmitter = require('events').EventEmitter
 
 var normalizeEntryPoints = require('./normalize-entry-points.js')
   , setupBundler = require('./setup-bundlers.js')
@@ -29,6 +30,7 @@ function parse(argv, cwd, ready) {
     , bundlerFlags = argv.slice(idx + 1)
     , legacyBundlerMode = false
     , entryPoints
+    , watchifyListener = new EventEmitter();
 
   // open options
   parsed.open = parsed.o || parsed.open
@@ -67,6 +69,7 @@ function parse(argv, cwd, ready) {
       , entryPoints
       , bundlerFlags
       , !parsed.watchify
+      , watchifyListener
       , onbundler
     )
   }
@@ -107,6 +110,7 @@ function parse(argv, cwd, ready) {
         command: parsed.bundler
       , flags: bundlerFlags
       , legacy: legacyBundlerMode
+      , watchifyListener: watchifyListener
     }
 
     ready(null, {

--- a/lib/bundlers/watchify.js
+++ b/lib/bundlers/watchify.js
@@ -5,7 +5,7 @@ var concat = require('concat-stream')
   , resolve = require('resolve')
   , through = require('through')
 
-function setupWatchify(dir, entryPoints, flags, ready) {
+function setupWatchify(dir, entryPoints, flags, watchifyListener, ready) {
   var watchify = require(dir)
 
   resolve('browserify/bin/args.js', {basedir: dir}, onmodule)
@@ -48,6 +48,10 @@ function setupWatchify(dir, entryPoints, flags, ready) {
     function buildWatchify(entry) {
       var watcher = watchify(parseArgs([entry].concat(flags)))
         , waiting = []
+
+      watcher.on('file', function(file) {
+        watchifyListener.emit('file', file)
+      })
 
       watcher.on('update', onupdate)
       watcher.on('error', onerror)
@@ -105,6 +109,7 @@ function setupWatchify(dir, entryPoints, flags, ready) {
         })
 
         build.pipe(concat(function(data) {
+          watchifyListener.emit('build')
           lastErr[entry] = null
           lastOut[entry] = data
 

--- a/lib/handlers/live-reload.js
+++ b/lib/handlers/live-reload.js
@@ -20,14 +20,23 @@ function handleLiveReload(opts, io, nextHandler) {
 
   var lastUpdate = Date.now()
     , pending = []
-
+    , watchifyIgnores = {}
+    
   watch(opts.cwd, {
-      ignored: ignore
+    ignored: function(path) {
+      return ignore.exec(path) || watchifyIgnores[path];
+    }
     , useFsEvents: true
     , usePolling: false
     , ignoreInitial: true
   }).on('all', onupdate)
-
+  
+  opts.bundler.watchifyListener.on('file', function(path) {
+    watchifyIgnores[path] = true;
+  })
+  
+  opts.bundler.watchifyListener.on('build', onupdate)
+  
   opts = opts.live
   opts.rate = +opts.rate || 1000
   opts.rate = Math.max(100, Math.min(opts.rate, 1000))

--- a/lib/handlers/live-reload.js
+++ b/lib/handlers/live-reload.js
@@ -47,14 +47,17 @@ function handleLiveReload(opts, io, nextHandler) {
     if(parsed.pathname === '/-/live-reload') {
       resp.writeHead(200, {'content-type': 'application/json'})
 
+      var timeout = setTimeout(pending[pending.length - 1], 60000);
+      
       pending.push(function ontimeout() {
+        clearTimeout(timeout)
         resp.end(JSON.stringify({
             lastUpdate: lastUpdate
         }))
         pending.splice(pending.indexOf(ontimeout), 1)
       })
 
-      return setTimeout(pending[pending.length - 1], 60000)
+      return timeout;
     }
 
     // script-injector expects to be able to wrap & execute

--- a/lib/setup-bundlers.js
+++ b/lib/setup-bundlers.js
@@ -9,7 +9,7 @@ var setupBrowserify = require('./bundlers/browserify.js')
 
 // local watchify, local browserify ->
 // global watchify, global browserify
-function setupBundler(cwd, entryPoints, flags, noWatchify, ready) {
+function setupBundler(cwd, entryPoints, flags, noWatchify, watchifyListener, ready) {
   noWatchify ?
     onlocalwatchify() :
     resolve('watchify', {basedir: cwd}, onlocalwatchify)
@@ -19,7 +19,7 @@ function setupBundler(cwd, entryPoints, flags, noWatchify, ready) {
       return resolve('browserify', {basedir: cwd}, onlocalbrowserify)
     }
 
-    setupWatchify(path.dirname(localDir), entryPoints, flags, ready)
+    setupWatchify(path.dirname(localDir), entryPoints, flags, watchifyListener, ready)
   }
 
   function onlocalbrowserify(err, localDir) {


### PR DESCRIPTION
**This pull request is not ready to merge**

I've been playing around with beefy and noticing that the live reloading is pretty unreliable, this is my first crack at fixing it. It works _very_ well now for me, but I still need to fix the tests and add some tests for this functionality.

Before I take that step of adding/fixing tests, I'd like to make sure that this approach looks solid:

I found out that the main problem is that `watchify` takes a while to build its bundle, but the live reload kicks in immediately, and serves up stale content before it can be rebuilt by `watchify`.

In order to get around this problem, I created a list of files which are managed by `watchify`, and ignore these files when watching for static file changes. Also, when `watchify` is finished with its build, I trigger a reload on the client. This ensures that the client update is only triggered when `watchify` is complete, and allows static files such as CSS to trigger a reload as well.

This approach seems to work really well for me. If this code looks OK, I'll go ahead and fix the tests and add more unit tests. If not, let me know how I can make it better!