### PR TITLE
Add handler to control access to localhost only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ Provide your own default index! This works great for single page apps,
 as every URL on your site will be redirected to the same HTML file. Every
 instance of `{{entry}}` will be replaced with the entry point of your app.
 
+#### `--localonly`
+
+Only permit requests from/to localhost, '127.0.0.1'.
+
 ## api
 
 ```javascript

--- a/lib/args-to-options.js
+++ b/lib/args-to-options.js
@@ -101,6 +101,7 @@ function parse(argv, cwd, ready) {
       , log: hasColor
       , cwd: parsed.cwd
       , realCwd: cwd
+      , localonly: parsed.localonly
     }
 
     handlerOptions.bundler = {

--- a/lib/create-handler.js
+++ b/lib/create-handler.js
@@ -10,6 +10,7 @@ var legacyBundle = require('./handlers/legacy-bundle.js')
   , modernBundle = require('./handlers/bundle.js')
   , serveStatic = require('./handlers/static.js')
   , logRequests = require('./handlers/log.js')
+  , gateKeeper = require('./handlers/gatekeeper.js')
 
 function createServer(opts, io, innerHandler) {
   var handlers
@@ -26,6 +27,7 @@ function createServer(opts, io, innerHandler) {
     , modernBundle
     , logRequests
     , liveReload
+    , gateKeeper
   ]
 
   handler = innerHandler || _404

--- a/lib/handlers/gatekeeper.js
+++ b/lib/handlers/gatekeeper.js
@@ -1,0 +1,20 @@
+module.exports = keepTheGate
+
+function keepTheGate(opts, io, nextHandler) {
+  if (!opts.localonly) {
+    return nextHandler;
+  }
+
+  return handle;
+
+  function handle(server, req, resp, parsed) {
+    // Only permit requests from/to localhost. All others will get 404.
+    if (req.socket.localAddress !== '127.0.0.1' ||
+	req.socket.remoteAddress !== '127.0.0.1') {
+      resp.writeHead(404, {'content-type': 'text/plain'})
+      resp.end('not found ):')
+    } else {
+      return nextHandler(server, req, resp, parsed);
+    }
+  }
+}


### PR DESCRIPTION
My corp security cops will not permit me to run beefy since a properly constructed request will serve up /etc/passwd and any other file on the machine. Restricting access to localhost makes them leave me alone.
