### PR TITLE
fixed incompatibility on node 4.1.0 on windows.

### DIFF
--- a/lib/accumulate-error.js
+++ b/lib/accumulate-error.js
@@ -22,7 +22,7 @@ function accumError(outputError, resp) {
 
   function end() {
     if(error.length) {
-      outputError(Buffer.concat(error))
+      outputError(error.toString())
       resp.end(
           '(' + DOMError + ')(' + JSON.stringify(error + '') + ')'
       )


### PR DESCRIPTION
I couldn't run beefy on node 4.1.0 on Windows because of something they changed in `Buffer.concat`. This change resolves the following error:
```

beefy (v2.1.5) is listening on http://127.0.0.1:9966
200    7ms       530B  / (generated)
buffer.js:229
    buf.copy(buffer, pos);
        ^

TypeError: buf.copy is not a function
    at Function.Buffer.concat (buffer.js:229:9)
    at Stream.end (C:\Users\Tomasz\AppData\Roaming\npm\node_modules\beefy\lib\accumulate-error.js:25:26)
    at _end (C:\Users\Tomasz\AppData\Roaming\npm\node_modules\beefy\node_modules\through\index.js:61:9)
    at Stream.stream.end (C:\Users\Tomasz\AppData\Roaming\npm\node_modules\beefy\node_modules\through\index.js:70:5)
    at Stream.onend (stream.js:59:10)
    at emitNone (events.js:72:20)
    at Stream.emit (events.js:166:7)
    at drain (C:\Users\Tomasz\AppData\Roaming\npm\node_modules\beefy\node_modules\through\index.js:33:23)
    at Stream.stream.queue.stream.push (C:\Users\Tomasz\AppData\Roaming\npm\node_modules\beefy\node_modules\through\index.js:41:5)
    at Stream.end (C:\Users\Tomasz\AppData\Roaming\npm\node_modules\beefy\node_modules\through\index.js:17:35)
npm ERR! Test failed.  See above for more details.

```