### PR TITLE
Convert strings to buffers

### DIFF
--- a/lib/accumulate-error.js
+++ b/lib/accumulate-error.js
@@ -22,10 +22,12 @@ function accumError(outputError, resp) {
 
   function end() {
     if(error.length) {
-      var buffers = [];
-      for (var i = 0; i < error.length; i++) {
-          buffers.push(Buffer(error[i]));
+      var buffers = []
+
+      for(var i = 0; i < error.length; ++i) {
+        buffers.push(Buffer(error[i]))
       }
+
       outputError(Buffer.concat(buffers))
       resp.end(
           '(' + DOMError + ')(' + JSON.stringify(error + '') + ')'

--- a/lib/accumulate-error.js
+++ b/lib/accumulate-error.js
@@ -22,7 +22,11 @@ function accumError(outputError, resp) {
 
   function end() {
     if(error.length) {
-      outputError(Buffer.concat(error))
+      var buffers = [];
+      for (var i = 0; i < error.length; i++) {
+          buffers.push(Buffer(error[i]));
+      }
+      outputError(Buffer.concat(buffers))
       resp.end(
           '(' + DOMError + ')(' + JSON.stringify(error + '') + ')'
       )


### PR DESCRIPTION
In Node 4+, beefy is broken because Buffer.concat doesn't
work on a list of strings.