### PR TITLE
respond with a utf-8 charset

### DIFF
--- a/lib/handlers/default-index.js
+++ b/lib/handlers/default-index.js
@@ -33,7 +33,7 @@ function handleDefault(opts, io, nextHandler) {
 
       parsed.loggedPathname = ansicolors.blue(parsed.pathname) +
         ' (' + ansicolors.blue('generated') + ')'
-      resp.setHeader('content-type', 'text/html')
+      resp.setHeader('content-type', 'text/html; charset=utf-8')
       resp.end(data.replace(
           /\{\{entry\}\}/g
         , Object.keys(opts.entries || {})[0] || ''

--- a/test/tests/handler-default-index.js
+++ b/test/tests/handler-default-index.js
@@ -112,6 +112,31 @@ function testDefaultIndexHandler(test) {
     }
   })
 
+  test('responds with a utf-8 charset', function(assert) {
+    var handler = defaultIndex({
+            generatedIndex: __filename
+        }, {error: logError}, _404)
+      , err = new Error
+      , logged = null
+
+    runServerAndRequest(handler, {accept: 'html'}, function(res, body) {
+      fs.readFile(
+          __filename
+        , 'utf8'
+        , onread
+      )
+
+      function onread(err, str) {
+        assert.equal(res.headers['content-type'], 'text/html; charset=utf-8')
+        assert.end()
+      }
+    })
+
+    function logError(what) {
+      logged = what
+    }
+  })
+
   test('accepts http requests without accept headers', function(assert) {
     var handler = defaultIndex({}, {error: logError}, _404)
       , err = new Error


### PR DESCRIPTION
By default, the beefy server doesn't add `charset=utf-8` to the `Content-Type` header, so UTF-8 characters aren't returned properly. Adding this to the header fixes this:

Before:

<img width="330" alt="screenshot 2016-05-17 17 32 20" src="https://cloud.githubusercontent.com/assets/2454505/15343827/6115afbc-1c55-11e6-98e0-fae882cb71ca.png">

After:

<img width="157" alt="screenshot 2016-05-17 17 31 51" src="https://cloud.githubusercontent.com/assets/2454505/15343828/6694ee76-1c55-11e6-952d-6a4978674788.png">
