### PR TITLE
Added Buffer.from in accumulate-error.js due to deprecation of simple…

### DIFF
--- a/lib/accumulate-error.js
+++ b/lib/accumulate-error.js
@@ -25,7 +25,7 @@ function accumError(outputError, resp) {
       var buffers = []
 
       for(var i = 0; i < error.length; ++i) {
-        buffers.push(Buffer(error[i]))
+        buffers.push(Buffer.from(error[i]))
       }
 
       outputError(Buffer.concat(buffers))


### PR DESCRIPTION
Line 28 of accumulate-error.js contained

```
buffers.push(Buffer(error[i]))
```

Beginning with Node v7 this is generating a warning of future deprecation so it was replaced by

```
buffers.push(Buffer.from(error[i]))
```