### PR TITLE
live-reload: Do not test for 'text/html' with equality test

### DIFF
--- a/lib/handlers/live-reload.js
+++ b/lib/handlers/live-reload.js
@@ -1,6 +1,7 @@
 module.exports = handleLiveReload
 
 var responsify = require('response-stream')
+  , contentType = require('content-type')
   , inject = require('script-injector')
   , ignore = require('ignorepatterns')
   , watch = require('chokidar').watch
@@ -12,6 +13,14 @@ var liveReloadCode = fs.readFileSync(
     path.join(__dirname, '..', 'frontend-js', 'live-reload.js')
   , 'utf8'
 )
+
+function isCType(headerStr) {
+  return headerStr.toLowerCase() === 'content-type'
+}
+
+function isHTML(cTypeStr) {
+  return contentType.parse(cTypeStr).type === 'text/html'
+}
 
 function handleLiveReload(opts, io, nextHandler) {
   if(!opts.live) {
@@ -70,11 +79,8 @@ function handleLiveReload(opts, io, nextHandler) {
     return nextHandler(server, req, lazyResponse, parsed)
 
     function setHeaderListener(args, prevent) {
-      var isCType = args[0].toLowerCase() === 'content-type'
-        , isHTML = args[1].toLowerCase() === 'text/html'
-
-      if(isCType) {
-        if(isHTML) {
+      if(isCType(args[0])) {
+        if(isHTML(args[1])) {
           lazyResponse.pipe(injector)
         } else {
           lazyResponse.pipe(resp)
@@ -87,11 +93,8 @@ function handleLiveReload(opts, io, nextHandler) {
 
     function writeHeadListener(args, prevent) {
       var hasCType = 'content-type' in args[1]
-        , isHTML
 
-      isHTML = args[1]['content-type'] === 'text/html'
-
-      if(hasCType && isHTML) {
+      if(hasCType && isHTML(args[1]['content-type'])) {
         lazyResponse.pipe(injector)
       } else {
         lazyResponse.pipe(resp)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ansicolors": "~0.3.2",
     "chokidar": "^1.0.0",
     "concat-stream": "^1.4.3",
+    "content-type": "^1.0.4",
     "find-global-packages": "0.0.1",
     "ignorepatterns": "^1.0.1",
     "leftpad": "0.0.0",


### PR DESCRIPTION
Use 'content-type' module instead, to correctly support parameters
like 'encoding'.

Fixes bug #107